### PR TITLE
Finalize export timetable use case with tests

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -151,7 +151,7 @@ public class Main {
                 DeleteSectionInputBoundary deleteCourseInteractor =
                         new DeleteSectionInteractor(timetableDataAccess, deleteSectionPresenter);
                 ExportTimetableInputBoundary exportTimetableInteractor =
-                        new ExportTimetableInteractor(exportPresenter, timetableDataAccess, courseDataAccess, exportDataAccess);
+                        new ExportTimetableInteractor(exportPresenter, timetableDataAccess, exportDataAccess);
                 ImportTimetableInputBoundary importTimetableInteractor =
                         new ImportTimetableInteractor(importPresenter, timetableDataAccess, courseDataAccess, importDataAccess);
 

--- a/src/main/java/usecase/export/ExportTimetableInteractor.java
+++ b/src/main/java/usecase/export/ExportTimetableInteractor.java
@@ -5,6 +5,10 @@ import entity.*;
 
 import java.util.List;
 
+/**
+ * Interactor for exporting a timetable.
+ * Currently, only JSON import is supported.
+ */
 public class ExportTimetableInteractor implements ExportTimetableInputBoundary {
     private final ExportTimetableOutputBoundary presenter;
     private final TimetableDataAccessInterface timetableDataAccess;
@@ -23,6 +27,10 @@ public class ExportTimetableInteractor implements ExportTimetableInputBoundary {
         this.exportDataAccess = exportDataAccess;
     }
 
+    /**
+     * Execute the interactor
+     * @param inputData the input data, which contains the filepath requested by the user.
+     */
     @Override
     public void execute(ExportTimetableInputData inputData) {
         try {

--- a/src/main/java/usecase/export/ExportTimetableInteractor.java
+++ b/src/main/java/usecase/export/ExportTimetableInteractor.java
@@ -1,29 +1,23 @@
 package usecase.export;
 
-import data_access.CourseDataAccessInterface;
 import data_access.TimetableDataAccessInterface;
 import entity.*;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import java.util.List;
 
 public class ExportTimetableInteractor implements ExportTimetableInputBoundary {
     private final ExportTimetableOutputBoundary presenter;
     private final TimetableDataAccessInterface timetableDataAccess;
-    private final CourseDataAccessInterface courseDataAccess;
     private final ExportTimetableDataAccessInterface exportDataAccess;
 
     public ExportTimetableInteractor(ExportTimetableOutputBoundary presenter,
                                      TimetableDataAccessInterface timetableDataAccess,
-                                     CourseDataAccessInterface courseDataAccess,
                                      ExportTimetableDataAccessInterface exportDataAccess
     ) {
-        if (timetableDataAccess == null || courseDataAccess == null || presenter == null || exportDataAccess == null) {
+        if (timetableDataAccess == null || presenter == null || exportDataAccess == null) {
             throw new IllegalArgumentException("Dependencies cannot be null");
         }
 
-        this.courseDataAccess =  courseDataAccess;
         this.timetableDataAccess = timetableDataAccess;
         this.presenter = presenter;
         this.exportDataAccess = exportDataAccess;

--- a/src/main/java/usecase/importsections/ImportTimetableInteractor.java
+++ b/src/main/java/usecase/importsections/ImportTimetableInteractor.java
@@ -54,6 +54,7 @@ public class ImportTimetableInteractor implements ImportTimetableInputBoundary {
                         Section section = course.getSectionByCode(sectionCode);
                         timetableDataAccess.addSection(section);
                         outputData.incrementSectionsAdded();
+
                         // Convert TimeSlots to TimeSlotData
                         List<AddCourseOutputData.TimeSlotData> timeSlotDatas = new ArrayList<>();
                         for (TimeSlot timeSlot : section.getTimes()) {
@@ -64,6 +65,7 @@ public class ImportTimetableInteractor implements ImportTimetableInputBoundary {
                                     timeSlot.getBuilding() != null ? timeSlot.getBuilding().getBuildingCode() : "TBD"
                             ));
                         }
+
                         AddCourseOutputData addCourseOutputData = new AddCourseOutputData(
                                 courseCode,
                                 sectionCode,

--- a/src/main/java/view/ExportImportPanel.java
+++ b/src/main/java/view/ExportImportPanel.java
@@ -14,6 +14,9 @@ import java.awt.FileDialog;
 
 public class ExportImportPanel extends JPanel implements PropertyChangeListener {
 
+    private final String EXPORT_DIRECTORY = System.getProperty("user.dir");
+    private final String DEFAULT_EXPORT_NAME = "courseExport.json";
+
     private JButton exportButton;
     private JButton importButton;
 
@@ -189,10 +192,12 @@ public class ExportImportPanel extends JPanel implements PropertyChangeListener 
 
     @Nullable
     private String runSaveFileDialog() {
-        FileDialog fileDialog = new FileDialog((Frame) SwingUtilities.getWindowAncestor(this), "Save", FileDialog.SAVE);
-        String currentDirectory = System.getProperty("user.dir");
-        fileDialog.setDirectory(currentDirectory);
-        fileDialog.setFile(currentDirectory + "\\" + "courseExport.json");
+        FileDialog fileDialog = new FileDialog(
+                (Frame) SwingUtilities.getWindowAncestor(this),
+                "Save",
+                FileDialog.SAVE);
+        fileDialog.setDirectory(EXPORT_DIRECTORY);
+        fileDialog.setFile(EXPORT_DIRECTORY + "\\" + DEFAULT_EXPORT_NAME);
         fileDialog.setVisible(true);
         if (fileDialog.getFile() == null) {
             return null;

--- a/src/test/java/usecase/export/ExportTimetableInteractorTest.java
+++ b/src/test/java/usecase/export/ExportTimetableInteractorTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -145,7 +146,8 @@ public class ExportTimetableInteractorTest {
 
     private static boolean deleteTempFile() throws IOException {
         try {
-            Files.delete(Paths.get(TEMP_LOCATION));
+            Path path = Paths.get(TEMP_LOCATION);
+            Files.delete(path);
             return true;
         }
         catch (NoSuchFileException e) {
@@ -169,8 +171,8 @@ public class ExportTimetableInteractorTest {
         );
 
         ExportTimetableInputData inputData = new ExportTimetableInputData(TEMP_LOCATION);
-        deleteTempFile();
         interactor.execute(inputData);
+        deleteTempFile();
 
         assertEquals(dummyPresenter.getStatus(), SUCCESS_VALUE);
 

--- a/src/test/java/usecase/export/ExportTimetableInteractorTest.java
+++ b/src/test/java/usecase/export/ExportTimetableInteractorTest.java
@@ -1,0 +1,393 @@
+package usecase.export;
+
+import data_access.CourseDataAccessInterface;
+import data_access.ExportDataAccess;
+import data_access.TimetableDataAccessInterface;
+import entity.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Test class for all parts of the export timetable use case.
+ * Tests the interactor, as well as the data access itself and its methods.
+ */
+public class ExportTimetableInteractorTest {
+    final static String TEMP_LOCATION =
+            System.getProperty("user.dir") + "/src/test/java/usecase/export/tempfiles/exportTest.json";
+
+    final int SUCCESS_VALUE = 1;
+    final int CANCEL_VALUE = 2;
+    final int ERROR_VALUE = 3;
+
+    final static ExportDataAccess exportDataAccess = new ExportDataAccess();
+
+    /**
+     * Data access tests
+     */
+    @Test
+    void TestExportBlank() throws IOException {
+        List<Section> noSections = new ArrayList<>();
+
+        JSONObject jsonObject = getJsonWithTempLocation(exportDataAccess, noSections);
+
+        JSONObject correctObject = new JSONObject();
+
+        assertEquals(jsonObject.toString(), correctObject.toString());
+
+    }
+    @Test
+    void TestExportTwoCourses() throws IOException {
+        {
+            // Create two course objects in accordance with the relevant fields in Section and Course
+            List<Section> course1Sections = new ArrayList<>();
+            List<Section> course2Sections = new ArrayList<>();
+            Course course1 = new Course(
+                    "CSC110",
+                    "Foundations of CS 1",
+                    "The best course ever",
+                    1.0f,
+                    "F",
+                    course1Sections,
+                    null,
+                    5
+            );
+            Course course2 = new Course(
+                    "ENG100",
+                    "Psychological Torture",
+                    "The worst course ever",
+                    0.5f,
+                    "F",
+                    course2Sections,
+                    null,
+                    1
+            );
+            Section section1 = new Section(
+                    "LEC0101",
+                    new ArrayList<>(),
+                    0,
+                    new ArrayList<>(),
+                    0,
+                    course1
+            );
+            Section section2 = new Section(
+                    "TUT0101",
+                    new ArrayList<>(),
+                    0,
+                    new ArrayList<>(),
+                    0,
+                    course1
+            );
+            Section section3 = new Section(
+                    "LEC5101",
+                    new ArrayList<>(),
+                    0,
+                    new ArrayList<>(),
+                    0,
+                    course2
+            );
+            course1Sections.add(section1);
+            course1Sections.add(section2);
+            course2Sections.add(section3);
+
+            // Create a sectionsInTimetable object to pass into the export interactor
+            List<Section> sections = new ArrayList<>();
+            sections.add(section1);
+            sections.add(section2);
+            sections.add(section3);
+
+            JSONObject jsonObject = getJsonWithTempLocation(exportDataAccess, sections);
+
+            JSONObject correctObject = new JSONObject();
+            JSONArray csc110CorrectSections = new JSONArray()
+                    .put("LEC0101")
+                    .put("TUT0101");
+            JSONArray eng100CorrectSections = new JSONArray()
+                    .put("LEC5101");
+            correctObject.put("CSC110", csc110CorrectSections);
+            correctObject.put("ENG100", eng100CorrectSections);
+
+            assertEquals(jsonObject.toString(), correctObject.toString());
+        }
+    }
+
+
+    /**
+     * Run exportDataAccess.save(), but return it as a JSONObject instead of simply saving the file.
+     * Allows testing if the saved JSON matches expectations.
+     * @param exportDataAccess an ExportDataAccess object
+     * @param sectionsInTimetable the list of sections to export
+     * @return the exported JSON file, as a JSONObject
+     */
+    public static JSONObject getJsonWithTempLocation(ExportDataAccess exportDataAccess, List<Section> sectionsInTimetable) {
+        try {
+            exportDataAccess.save(TEMP_LOCATION, sectionsInTimetable);
+            String jsonString = Files.readString(Paths.get(TEMP_LOCATION));
+            JSONObject jsonObject = new JSONObject(jsonString);
+            deleteTempFile();
+            return jsonObject;
+        } catch (IOException | JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean deleteTempFile() throws IOException {
+        try {
+            Files.delete(Paths.get(TEMP_LOCATION));
+            return true;
+        }
+        catch (NoSuchFileException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Test that the right presenter function is being executed when the interactor executes.
+     *
+     * Success happens whenever a valid filepath is provided.
+     * Cancelled happens whenever null is provided as the filepath.
+     */
+    @Test
+    void TestPresenterSuccessful() throws IOException {
+        DummyPresenter dummyPresenter = new DummyPresenter();
+        ExportTimetableInteractor interactor = new ExportTimetableInteractor(
+                dummyPresenter,
+                new InMemoryTimetableDataAccess(),
+                exportDataAccess
+        );
+
+        ExportTimetableInputData inputData = new ExportTimetableInputData(TEMP_LOCATION);
+        deleteTempFile();
+        interactor.execute(inputData);
+
+        assertEquals(dummyPresenter.getStatus(), SUCCESS_VALUE);
+
+    }
+    @Test
+    void TestPresenterCancelled() throws IOException {
+        DummyPresenter dummyPresenter = new DummyPresenter();
+        ExportTimetableInteractor interactor = new ExportTimetableInteractor(
+                dummyPresenter,
+                new InMemoryTimetableDataAccess(),
+                exportDataAccess
+        );
+
+        ExportTimetableInputData inputData = new ExportTimetableInputData(null);
+        interactor.execute(inputData);
+
+        assertEquals(dummyPresenter.getStatus(), CANCEL_VALUE);
+
+    }
+    @Test
+    void TestPresenterError() throws IOException {
+        DummyPresenter dummyPresenter = new DummyPresenter();
+        ExportTimetableInteractor interactor = new ExportTimetableInteractor(
+                dummyPresenter,
+                new InMemoryTimetableDataAccess(),
+                new FaultyExportDataAccess()
+        );
+
+        ExportTimetableInputData inputData = new ExportTimetableInputData(TEMP_LOCATION);
+        deleteTempFile();
+        interactor.execute(inputData);
+
+        assertEquals(dummyPresenter.getStatus(), ERROR_VALUE);
+
+    }
+
+    /**
+     * Test interactor null dependency exception for each parameter
+     */
+    @Test
+    void TestNullDependencies() {
+        assertThrows(IllegalArgumentException.class, () -> new ExportTimetableInteractor(
+                new DummyPresenter(),
+                null,
+                exportDataAccess
+        ));
+        assertThrows(IllegalArgumentException.class, () -> new ExportTimetableInteractor(
+                null,
+                new InMemoryTimetableDataAccess(),
+                exportDataAccess
+        ));
+        assertThrows(IllegalArgumentException.class, () -> new ExportTimetableInteractor(
+                new DummyPresenter(),
+                new InMemoryTimetableDataAccess(),
+                null
+        ));
+
+    }
+
+
+    // ===============================================================
+    // Helper classes for testing.
+    // ===============================================================
+
+    public class DummyPresenter implements ExportTimetableOutputBoundary {
+        private int status;
+        // Status integer to detect what presenter method was called.
+
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void presentSuccess(ExportTimetableOutputData outputData) {
+            this.status = SUCCESS_VALUE;
+        }
+
+        @Override
+        public void presentCancel() {
+            this.status = CANCEL_VALUE;
+        }
+
+        @Override
+        public void presentError(String errorMessage) {
+            this.status = ERROR_VALUE;
+        }
+    }
+
+    private static class InMemoryTimetableDataAccess implements TimetableDataAccessInterface {
+        private final Timetable timetable = new Timetable();
+        private String currentTerm = null;
+        private boolean addSectionResult = true;
+        private boolean hasConflicts = false;
+
+        public void setCurrentTerm(String term) { this.currentTerm = term; }
+        public void setAddSectionResult(boolean result) { this.addSectionResult = result; }
+        public void setHasConflicts(boolean hasConflicts) { this.hasConflicts = hasConflicts; }
+
+        @Override
+        public boolean addSection(Section section) {
+            if (!addSectionResult) return false;
+            timetable.addSectionOfNewCourse(section);
+            if (currentTerm == null) currentTerm = section.getCourse().getTerm();
+            return true;
+        }
+
+        @Override
+        public boolean hasSection(Section section) {
+            for (TimetableBlock block : timetable.getBlocks()) {
+                if (block.getSection().equals(section)) return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean hasConflicts(Section section) { return hasConflicts; }
+
+        @Override
+        public String getCurrentTerm() { return currentTerm; }
+
+        @Override
+        public List<Section> getAllSections() {
+            List<Section> sections = new ArrayList<>();
+            for (TimetableBlock block : timetable.getBlocks()) {
+                Section section = block.getSection();
+                if (!sections.contains(section)) sections.add(section);
+            }
+            return sections;
+        }
+
+        @Override
+        public boolean removeSection(Section section) {
+            timetable.removeSection(section);
+            return true;
+        }
+
+        @Override
+        public Timetable getTimetable() { return timetable; }
+
+        @Override
+        public void clear() {
+            for (Course course : new ArrayList<>(timetable.getCourses())) timetable.removeCourse(course);
+            currentTerm = null;
+        }
+    }
+
+
+    private static class InMemoryCourseDataAccess implements CourseDataAccessInterface {
+        private final List<Course> courses = new ArrayList<>();
+
+        public InMemoryCourseDataAccess() {
+            Building ba = new Building("BA", "Bahen", 43.0, 79.0);
+
+            List<Section> csc207Sections = new ArrayList<>();
+            Course csc207 = new Course("CSC207", "Software Design", "Intro", 0.5f, "F", csc207Sections, ba, 5);
+            Section csc207Sec = new Section("LEC0101", List.of(new TimeSlot(1, LocalTime.of(10, 0), LocalTime.of(12, 0), ba)), 50, List.of("Dr. Smith"), 100, csc207);
+            csc207.addSection(csc207Sec);
+            courses.add(csc207);
+
+            List<Section> csc236Sections = new ArrayList<>();
+            Course csc236 = new Course("CSC236", "Theory", "Theory", 0.5f, "S", csc236Sections, ba, 5);
+            Section csc236Sec = new Section("LEC0101", List.of(new TimeSlot(1, LocalTime.of(10, 0), LocalTime.of(12, 0), ba)), 50, List.of("Dr. Winter"), 100, csc236);
+            csc236.addSection(csc236Sec);
+            courses.add(csc236);
+
+            List<Section> mat137Sections = new ArrayList<>();
+            Course mat137 = new Course("MAT137", "Calculus", "Year-long", 1.0f, "Y", mat137Sections, ba, 5);
+            Section mat137Sec = new Section("LEC0101", List.of(new TimeSlot(1, LocalTime.of(10, 0), LocalTime.of(12, 0), ba)), 50, List.of("Dr. Math"), 100, mat137);
+            mat137.addSection(mat137Sec);
+            courses.add(mat137);
+        }
+
+        @Override
+        public Course findByCourseCode(String courseCode) {
+            for (Course course : courses) {
+                if (course.getCourseCode().equals(courseCode)) return course;
+            }
+            return null;
+        }
+
+        @Override
+        public List<Course> getAllCourses() { return new ArrayList<>(courses); }
+    }
+
+    private static class FaultyExportDataAccess implements ExportTimetableDataAccessInterface {
+
+        @Override
+        public void save(String filepath, List<Section> sections) {
+            throw new RuntimeException("DB error");
+        }
+    }
+
+    private static class FaultyTimetableDataAccess implements TimetableDataAccessInterface {
+        @Override
+        public boolean addSection(Section section) { throw new RuntimeException("DB error"); }
+
+        @Override
+        public boolean hasSection(Section section) { throw new RuntimeException("DB error"); }
+
+        @Override
+        public boolean hasConflicts(Section section) { throw new RuntimeException("DB error"); }
+
+        @Override
+        public String getCurrentTerm() { throw new RuntimeException("DB error"); }
+
+        @Override
+        public List<Section> getAllSections() { throw new RuntimeException("DB error"); }
+
+        @Override
+        public boolean removeSection(Section section) { throw new RuntimeException("DB error"); }
+
+        @Override
+        public Timetable getTimetable() { throw new RuntimeException("DB error"); }
+
+        @Override
+        public void clear() { throw new RuntimeException("DB error"); }
+    }
+
+}
+


### PR DESCRIPTION
Adds test cases for the Export use case.

I have also included some test cases for the data access itself in the same file. These do not affect the code coverage, but they are good to include to make sure the underlying logic of the code and other tests holds.

Also removes a currently unused parameter of the export interactor.